### PR TITLE
ci: update kube-score

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,10 +43,10 @@ jobs:
         continue-on-error: true
         run: |
           helm template charts/trails > template.yaml
-          wget --no-verbose --show-progress --progress dot:giga https://github.com/zegl/kube-score/releases/download/v1.13.0/kube-score_1.13.0_linux_amd64.tar.gz
-          echo "e8b739c932ff8505ba80bb58e4e1a244c79caa9816f3db78171253634114c022  kube-score_1.13.0_linux_amd64.tar.gz" | sha256sum --check
-          tar xf kube-score_1.13.0_linux_amd64.tar.gz
-          ./kube-score score --output-format ci --kubernetes-version 1.22 template.yaml
+          wget --no-verbose --show-progress --progress dot:giga https://github.com/zegl/kube-score/releases/download/v1.19.0/kube-score_1.19.0_linux_amd64.tar.gz
+          echo "a5b10e509bd845f0bc32a529f4e8165c021877f924ee6f6be66678039f75a761  kube-score_1.19.0_linux_amd64.tar.gz" | sha256sum --check
+          tar xf kube-score_1.19.0_linux_amd64.tar.gz
+          ./kube-score score --output-format ci --kubernetes-version 1.32 template.yaml
 
   build:
     name: Build


### PR DESCRIPTION
This MR bumps the `kube-score` version from v1.13 to v1.19.